### PR TITLE
Improve decoupling

### DIFF
--- a/rsf.py
+++ b/rsf.py
@@ -25,6 +25,16 @@ from scipy import integrate
 from math import exp,log
 from collections import namedtuple
 
+def dieterichState(model):
+    return 1. - model.v * model.theta / model.dc
+
+def ruinaState(model):
+    return -1*(model.v * model.theta / model.dc)*log(model.v * model.theta / model.dc)
+
+def przState(model):
+    return 1. - (model.v * model.theta / (2*model.dc))**2
+
+
 class RateState(object):
     """
     Create a model for frictional behavior
@@ -63,18 +73,9 @@ class RateState(object):
         # <= the current time.
         loadpoint_vel = self.loadpoint_velocity[self.model_time<=t][-1]
         dmu_dt = self.k * (loadpoint_vel - self.v)
-        dtheta_dt = self.stateLaw()
+        dtheta_dt = self.stateLaw(self)
 
         return [dmu_dt,dtheta_dt]
-
-    def dieterichState(self):
-        return 1. - self.v * self.theta / self.dc
-
-    def ruinaState(self):
-        return -1*(self.v * self.theta / self.dc)*log(self.v * self.theta / self.dc)
-
-    def przState(self):
-        return 1. - (self.v * self.theta / (2*self.dc))**2
 
     def readyCheck(self):
         return True

--- a/shs_example.py
+++ b/shs_example.py
@@ -12,7 +12,7 @@ model.dc = 10. # Critical slip distance
 model.k = 1e-3 # Normalized System stiffness (friction/micron)
 model.v = 10. # Initial slider velocity, generally is vlp(t=0)
 model.vref = 10. # Reference velocity, generally vlp(t=0)
-model.stateLaw = model.dieterichState # Which state relation we want to use
+model.stateLaw = rsf.dieterichState # Which state relation we want to use
 
 # We want to solve for 40 seconds at 100Hz
 model.model_time = np.arange(0,150.01,0.01)

--- a/velocity_step_example.py
+++ b/velocity_step_example.py
@@ -12,7 +12,7 @@ model.dc = 10. # Critical slip distance
 model.k = 1e-3 # Normalized System stiffness (friction/micron)
 model.v = 1. # Initial slider velocity, generally is vlp(t=0)
 model.vref = 1. # Reference velocity, generally vlp(t=0)
-model.stateLaw = model.dieterichState # Which state relation we want to use
+model.stateLaw = rsf.dieterichState # Which state relation we want to use
 
 # We want to solve for 40 seconds at 100Hz
 model.model_time = np.arange(0,40.01,0.01)


### PR DESCRIPTION
This addresses the decoupling concerns in #2 by moving state evolution "laws" into separate functions. I kept passing the whole model object to them since they could potentially call anything the user wants to calculate theta. Maybe this is a clean approach?