### PR TITLE
Add Nagata Law

### DIFF
--- a/rsf.py
+++ b/rsf.py
@@ -69,6 +69,19 @@ class PrzState(StateRelation):
         return 1. - (system.v * self.state / (2 * self.Dc))**2
 
 
+class NagataState(StateRelation):
+    def __init__(self):
+        self.c = None
+
+    def _set_steady_state(self, system):
+        self.state = self.Dc / system.vref
+
+    def evolve_state(self, system):
+        if self.state is None:
+            self.state = _steady_state(self, system)
+        # return dtheta/dt
+        return 1. - (system.v * self.state / self.Dc) - (self.c / self.b * self.state * system.dmu_dt)
+
 class LoadingSystem(object):
     def __init__(self):
         self.k = None
@@ -83,7 +96,6 @@ class LoadingSystem(object):
 
     def friction_evolution(self, loadpoint_vel):
         return self.k * (loadpoint_vel - self.v)
-
 
 class Model(LoadingSystem):
     def __init__(self):
@@ -109,12 +121,11 @@ class Model(LoadingSystem):
         # <= the current time.
         loadpoint_vel = system.loadpoint_velocity[system.time <= t][-1]
 
-        dmu_dt = system.friction_evolution(loadpoint_vel)
-
-        step_results = [dmu_dt]
+        self.dmu_dt = system.friction_evolution(loadpoint_vel)
+        step_results = [self.dmu_dt]
 
         for state_variable in system.state_relations:
-            dtheta_dt = state_variable.evolve_state(system)
+            dtheta_dt = state_variable.evolve_state(self)
             step_results.append(dtheta_dt)
 
         return step_results


### PR DESCRIPTION
Added the Nagata state evolution relation. This depends on dmu/dt, so I made that an attribute in the model object so it could be accessed by the `evolve_state` method. Also just passed the model object to the state laws since it inherits all attributes of `LoadingSystem`. Addresses #12 

![screen shot 2015-05-28 at 7 49 09 am](https://cloud.githubusercontent.com/assets/325269/7859344/0c1e1a8a-050e-11e5-81b7-70f1ba525f55.png)